### PR TITLE
Add entries for 'How to edit menu' and 'Display keybinds'

### DIFF
--- a/.config/openbox/menu.xml
+++ b/.config/openbox/menu.xml
@@ -409,6 +409,13 @@
         </menu>
         <menu id="help" label="Help" execute="bl-help-pipemenu" />
         <separator/>
+        <item label="HowTo edit menu">
+            <action name="Execute">
+                <command>zenity --text-info --title="How to Edit the Menu" --filename="/usr/lib/bunsen/bunsen-docs/helpfile-menu.txt" --width=900 --height=700</execute>
+            </command>
+        </item>
+        <menu execute="/usr/bin/bl-kb-pipemenu" id="keybinds" label="Display keybinds"/>
+        <separator/>
         <item label="Lock Screen">
             <action name="Execute">
                 <command>


### PR DESCRIPTION
'How to edit menu' is for a common new user's question - it uses a helpfile in bunsen-docs;

'Display keybinds' uses the bl-kb-pipemenu and bl-kb.py. 'Run' commands in the menu items are clickable.
