### PR TITLE
skel/.Xresources: set iconFile to correct urxvt icon

### DIFF
--- a/skel/.Xresources
+++ b/skel/.Xresources
@@ -51,7 +51,7 @@ URxvt.geometry: 80x28
 URxvt.scrollstyle: plain
 URxvt.scrollBar: true
 URxvt.scrollBar_right: true
-URxvt.iconFile: /usr/share/icons/Faenza-Bunsen-common/apps/48/utilities-terminal.png
+URxvt.iconFile: /usr/share/pixmaps/urxvt_48x48.xpm
 
 ! Grey theming
 !URxvt*background: #cecece


### PR DESCRIPTION
The rxvt-unicode-256color package places .xpm icon files in /usr/share/pixmaps — probably best to use those rather than a generic terminal icon?