### PR TITLE
Darkened screenshots fix

### DIFF
--- a/skel/.config/compton.conf
+++ b/skel/.config/compton.conf
@@ -11,7 +11,7 @@ shadow-opacity = 0.4;
 # shadow-green = 0.0;
 # shadow-blue = 0.0;
 #shadow-exclude = [ "n:e:xfce4-notifyd", "i:e:Conky" ];
-shadow-exclude = [ "i:e:Conky" ];
+shadow-exclude = [ "i:e:Conky", "i:e:xfce4-screenshooter" ];
 #shadow-ignore-shaped = false;
 
 # Opacity


### PR DESCRIPTION
xfce4-screenshooter not behaving properly with compositing on.