### PR TITLE
tint2rc: set task_font to Sans 9

### DIFF
--- a/skel/.config/tint2/tint2rc
+++ b/skel/.config/tint2/tint2rc
@@ -106,7 +106,7 @@ task_urgent_icon_asb = 100 0 0
 task_iconified_icon_asb = 80 0 0
 
 # Fonts
-task_font = Sans 06_55 6
+task_font = Sans 9
 task_font_color = #828282 60
 task_active_font_color = #828282 100
 task_urgent_font_color = #FFFFFF 100

--- a/skel/.config/tint2/tint2rc-bottom
+++ b/skel/.config/tint2/tint2rc-bottom
@@ -106,7 +106,7 @@ task_urgent_icon_asb = 100 0 0
 task_iconified_icon_asb = 80 0 0
 
 # Fonts
-task_font = Sans 06_55 6
+task_font = Sans 9
 task_font_color = #828282 60
 task_active_font_color = #828282 100
 task_urgent_font_color = #FFFFFF 100


### PR DESCRIPTION
As task_text = 0, it does not change the appearance of tint2.

It makes the font in jgmenu look right without having to edit the config file.