### PR TITLE
skel/.profile: startx automatically for tty1 login.

### DIFF
--- a/skel/.profile
+++ b/skel/.profile
@@ -53,3 +53,6 @@ if [ "$TERM" = "linux" ]; then
     printf "\e]PFffffff" # color15
 #   clear # removes artefacts but also removes /etc/{issue,motd}
 fi
+
+# launch desktop automatically from a console login (TTY1 only)
+[ "$(tty)" = "/dev/tty1" ] && exec startx


### PR DESCRIPTION
See https://forums.bunsenlabs.org/viewtopic.php?id=4477

The added line will start the desktop automatically if the users logs in to the console at TTY1 and will allow a seamless user experience for those who choose to purge LightDM.

The line does not affect LightDM logins or any TTYs apart from the first.
