### PR TITLE
skel/.profile: added warning for TTY first boot.

### DIFF
--- a/skel/.profile
+++ b/skel/.profile
@@ -53,3 +53,16 @@ if [ "$TERM" = "linux" ]; then
     printf "\e]PFffffff" # color15
 #   clear # removes artefacts but also removes /etc/{issue,motd}
 fi
+
+if [[  ! -f "${HOME}/.config/bunsen/bl-setup" && "$TERM" = "linux" ]]; then
+   echo'
+   ########################################################
+   #                                                      #
+   #    Warning: no user configuration files detected!    #
+   #                                                      #
+   # Please run `bl-user-setup` to configure the desktop. #
+   #                                                      #
+   ########################################################
+   '
+fi
+


### PR DESCRIPTION
If the TTY option is selected from the first boot after installation then `startx` will result in an unconfigured desktop.

This change prints a warning and an instruction if this is the case.