### PR TITLE
terminator: tweaked default red and green profile colors

### DIFF
--- a/skel/.config/terminator/config
+++ b/skel/.config/terminator/config
@@ -23,7 +23,7 @@
     cursor_color_fg = False
     font = Monospace 11
     foreground_color = "#add8e6"
-    palette = "#555753:#a40000:#729fcf:#d9c964:#204a87:#9a64d9:#64d9d5:#d3d7cf:#babdb6:#d98f93:#13b9b9:#d9cf8f:#8f99d9:#b08fd9:#8fd9d5:#c5c5c5"
+    palette = "#555753:#b44444:#5ecb8c:#d9c964:#204a87:#9a64d9:#64d9d5:#d3d7cf:#babdb6:#d98f93:#13b9b9:#d9cf8f:#8f99d9:#b08fd9:#8fd9d5:#c5c5c5"
     scrollback_infinite = True
     scrollback_lines = 5000
     scrollbar_position = hidden


### PR DESCRIPTION
* made the red more contrasting with background, so that it's more readable
* replaced light blue by green. Important for commands using red/green colors with semantic meaning for negative/positive.

For comparison: output of git diff command before and after this change.

![default](https://user-images.githubusercontent.com/925443/38832422-ca8812c0-41c2-11e8-8ca8-c7fba9db1340.png)

![update](https://user-images.githubusercontent.com/925443/38832428-cd2e807c-41c2-11e8-91c0-ac392516fc3f.png)
