### PR TITLE
readability: increased contrast for dark blue text

### DIFF
--- a/skel/.config/terminator/config
+++ b/skel/.config/terminator/config
@@ -23,7 +23,7 @@
     cursor_color_fg = False
     font = Monospace 11
     foreground_color = "#add8e6"
-    palette = "#555753:#b44444:#5ecb8c:#d9c964:#204a87:#9a64d9:#64d9d5:#d3d7cf:#babdb6:#d98f93:#13b9b9:#d9cf8f:#8f99d9:#b08fd9:#8fd9d5:#c5c5c5"
+    palette = "#555753:#b44444:#5ecb8c:#d9c964:#3d6aac:#9a64d9:#64d9d5:#d3d7cf:#babdb6:#d98f93:#13b9b9:#d9cf8f:#8f99d9:#b08fd9:#8fd9d5:#c5c5c5"
     scrollback_infinite = True
     scrollback_lines = 5000
     scrollbar_position = hidden


### PR DESCRIPTION
The changes makes the dark blue text more readable.

In the current setup, the dark blue is very close to the terminal's background color, causing problems to distinguish the text.

Before:

![screenshot_2018-04-22_14-27-30](https://user-images.githubusercontent.com/925443/39095065-7c9bd14c-463a-11e8-9e84-efa81efe7461.png)


After:

![screenshot_2018-04-22_14-30-49](https://user-images.githubusercontent.com/925443/39095067-825abc24-463a-11e8-95a3-38d3ca1b40c3.png)
