### PR TITLE
mpv: Fix unwanted window when playing audio stream from terminal

### DIFF
--- a/bin/bl-mpv
+++ b/bin/bl-mpv
@@ -2,7 +2,7 @@
 
 # wrapper for mpv to enable use as alternative for bl-media-player
 
-MPV_PROFILE=pseudo-gui
+MPV_PROFILE=bl-pseudo-gui
 
 if ! hash mpv; then
     echo "$0: mpv binary is missing. Please issue 'sudo apt-get install mpv'." >&2
@@ -10,13 +10,19 @@ if ! hash mpv; then
 fi
 
 if (( $# > 0 )); then
-    FILE=$1
+    URI=$1
 
     # Use the MIME type of the first file passed to us to determine the
     # playback profile.
-    if [[ -s "$FILE" && "$(file --mime-type --brief "$FILE")" =~ ^audio/ ]]; then
+    if [[ -s "$URI" && "$(file --mime-type --brief "$URI")" =~ ^audio/ ]]; then
         MPV_PROFILE=audio-only
+    else
+        case "$URI" in
+        http://*|https://*)
+            MPV_PROFILE=http-https
+           ;;
+        esac
     fi
 fi
 
-exec mpv --terminal=no --input-terminal=no --profile=$MPV_PROFILE "$@"
+exec mpv --profile=$MPV_PROFILE "$@"

--- a/bin/bl-mpv
+++ b/bin/bl-mpv
@@ -18,9 +18,15 @@ if (( $# > 0 )); then
         MPV_PROFILE=audio-only
     else
         case "$URI" in
-        http://*|https://*)
-            MPV_PROFILE=http-https
-           ;;
+        http://*)
+            MPV_PROFILE=bl-http
+            ;;
+        https://*)
+            MPV_PROFILE=bl-https
+            ;;
+        ytdl://*)
+            MPV_PROFILE=bl-ytdl
+            ;;
         esac
     fi
 fi

--- a/mpv/mpv.conf
+++ b/mpv/mpv.conf
@@ -21,12 +21,15 @@ hwdec=auto
 script-opts=osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=10,osc-vidscale=no,osc-scalewindowed=2.0,osc-scalefullscreen=2.0
 
 # not auto-loaded but invoked by bl-mpv
-[http-https]
+[bl-http]
 profile=bl-pseudo-gui
 force-window=immediate
 
-[protocol.ytdl]
-profile=http-https
+[bl-https]
+profile=bl-http
+
+[bl-ytdl]
+profile=bl-http
 ytdl-format=best[height=720]
 
 # Used by bl-mpv.

--- a/mpv/mpv.conf
+++ b/mpv/mpv.conf
@@ -18,20 +18,24 @@ hwdec=auto
 
 # Configuration options for the on-screen display in regular playback
 # mode.
-script-opts=osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=10,osc-vidscale=no,osc-scalewindowed=2.0,osc-scalefullscreen=2.0 
+script-opts=osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=10,osc-vidscale=no,osc-scalewindowed=2.0,osc-scalefullscreen=2.0
 
-[protocol.http]
+# not auto-loaded but invoked by bl-mpv
+[http-https]
+profile=bl-pseudo-gui
 force-window=immediate
 
-[protocol.https]
-profile=protocol.http
-
 [protocol.ytdl]
-profile=protocol.http
+profile=http-https
 ytdl-format=best[height=720]
 
 # Used by bl-mpv.
+[bl-pseudo-gui]
+player-operation-mode=pseudo-gui
+input-terminal=no
+screenshot-directory=~/Pictures/screenshots/
+
 [audio-only]
-profile=pseudo-gui
+profile=bl-pseudo-gui
 script-opts=osc-layout=box,osc-visibility=always,osc-scaleforcedwindow=3,osc-valign=0
 geometry=35%x25%


### PR DESCRIPTION
Suggested workaround for issues #86 and #87.

I'm assuming mpv has no deeper knowlege of the file transfer protocol than the start of the URI, so testing it in `bl-mpv` before choosing a profile, replacing use of mpv's auto profiles [protocol.http], [protocol.https] and [protocol-ytdl]. This leaves the `mpv` command relatively close to the factory default settings.

**bin/bl-mpv:** Use custom [bl-pseudo-gui] profile to invoke pseudo-GUI mode.
    Test for http{,s} or ytdl protocols and invoke new [bl-http], [bl-https] or [bl-ytdl] profile.
    Remove '--terminal=no' and '--input-terminal=no' from command line;
     they are invoked in mpv's [builtin-pseudo-gui] and our [bl-pseudo-gui].

**mpv/mpv.conf:** Add [bl-http], [bl-https] and [bl-ytdl], invoked from bl-mpv,
     to replace the auto profiles [protocol.http], [protocol.https] and [protocol-ytdl].
    Add [bl-pseudo-gui] to invoke pseudo-gui mode and set screenshot directory;
     this replaces calls to the deprecated [pseudo-gui] profile (see man mpv).