### PR TITLE
menu.xml: replace odd <execute> tag with <command>

### DIFF
--- a/skel/.config/openbox/menu.xml
+++ b/skel/.config/openbox/menu.xml
@@ -357,8 +357,9 @@
             <separator/>
             <item label="About Bunsen Alternatives">
                 <action name="Execute">
-                    <execute>yad --button="OK":0 --center --window-icon=distributor-logo-bunsenlabs --text-info --title=&quot;About Bunsen Alternatives&quot; --filename=&quot;/usr/share/bunsen/docs/helpfile-bl-alternatives.txt&quot; --width=900 --height=700 --fontname=Monospace
-                    </execute>
+                    <command>
+                        yad --button="OK":0 --center --window-icon=distributor-logo-bunsenlabs --text-info --title=&quot;About Bunsen Alternatives&quot; --filename=&quot;/usr/share/bunsen/docs/helpfile-bl-alternatives.txt&quot; --width=900 --height=700 --fontname=Monospace
+                    </command>
                 </action>
             </item>
         </menu>


### PR DESCRIPTION
Increase consistency by using <command> tags throughout menu.xml file.

The openbox.org wiki says that the <execute> tag is depreciated.

http://openbox.org/wiki/Help:Actions#Action_syntax

Same as c217aa3c on helium branch