### PR TITLE
bin/bunsenlabs-session: only import jgmenu config if all files missing

### DIFF
--- a/bin/bunsenlabs-session
+++ b/bin/bunsenlabs-session
@@ -16,12 +16,19 @@ usr_confdir="${XDG_CONFIG_HOME:-$HOME/.config}"
 sys_confdir="/usr/share/bunsen/skel/.config"
 # Import new user config files if they do not exist.
 # This is for users upgrading or installing with the Bunsenlabs metapackage.
-for i in bunsen/autostart bunsen/environment openbox/bl-rc.xml openbox/bl-menu.xml jgmenu/prepend.csv jgmenu/jgmenurc
+for i in bunsen/autostart bunsen/environment openbox/bl-rc.xml openbox/bl-menu.xml
 do
     mkdir -p "$usr_confdir/${i%/*}"
     [ -e "$usr_confdir/$i" ] || cp "$sys_confdir/$i" "$usr_confdir/$i"
 done
 [ -e "$HOME/.xbindkeysrc" ] || cp /usr/share/bunsen/skel/.xbindkeysrc "$HOME"
+
+# Only import jgmenu config files if both jgmenurc and prepend.csv are missing
+if ! [ -e  "$usr_confdir/jgmenu/jgmenurc" ] && \
+   ! [ -e  "$usr_confdir/jgmenu/jgmenurc" ]; then
+    mkdir -p "$usr_confdir/jgmenu"
+    cp -a "$sys_confdir/jgmenu/" "$usr_confdir/"
+fi
 
 usr_autostart="$usr_confdir/bunsen/autostart"
 usr_envfile="$usr_confdir/bunsen/environment"


### PR DESCRIPTION
Themes other than 'bunsenlabs-lithium' may not use all config files
(jgmenurc, prepend.csv, append.csv), so files must only be imported if
all are missing.