### PR TITLE
bin/bl-xdg-autostart: update to python3

### DIFF
--- a/bin/bl-xdg-autostart
+++ b/bin/bl-xdg-autostart
@@ -1,9 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # openbox-xdg-autostart runs things based on the XDG autostart specification
 # Copyright (C) 2008       Dana Jansens
 #
 # Renamed to bl-xdg-autostart for BunsenLabs Linux 2019
+# Upgraded to use python3 for BunsenLabs Linux 2020
 #
 # XDG autostart specification can be found here:
 # http://standards.freedesktop.org/autostart-spec/
@@ -30,9 +31,9 @@ try:
     from xdg.DesktopEntry import DesktopEntry
     from xdg.Exceptions import ParsingError
 except ImportError:
-    print
-    print >>sys.stderr, "ERROR:", ME, "requires PyXDG to be installed"
-    print
+    print()
+    print("ERROR:", ME, "requires PyXDG to be installed", file=sys.stderr)
+    print()
     sys.exit(1)
 
 def main(argv=sys.argv):
@@ -53,7 +54,7 @@ def main(argv=sys.argv):
             try:
                 autofile = AutostartFile(path)
             except ParsingError:
-                print "Invalid .desktop file: " + path
+                print("Invalid .desktop file: " + path)
             else:
                 if not autofile in files:
                     files.append(autofile)
@@ -101,9 +102,9 @@ class AutostartFile:
 
     def _alert(self, str, info=False):
         if info:
-            print "\t ", str
+            print("\t ", str)
         else:
-            print "\t*", str
+            print("\t*", str)
 
     def _showInEnvironment(self, envs, verbose=False):
         default = not self.de.getOnlyShowIn()
@@ -148,14 +149,14 @@ class AutostartFile:
 
     def display(self, envs):
         if self._shouldRun(envs):
-            print "[*] " + self.de.getName()
+            print("[*] " + self.de.getName())
         else:
-            print "[ ] " + self.de.getName()
+            print("[ ] " + self.de.getName())
         self._alert("File: " + self.path, info=True)
         if self.de.getExec():
             self._alert("Executes: " + self.de.getExec(), info=True)
         self._shouldRun(envs, True)
-        print
+        print()
 
     def run(self, envs):
         here = os.getcwd()
@@ -167,38 +168,38 @@ class AutostartFile:
         os.chdir(here)
 
 def show_help():
-    print "Usage:", ME, "[OPTION]... [ENVIRONMENT]..."
-    print
-    print "This tool will run xdg autostart .desktop files"
-    print
-    print "OPTIONS"
-    print "  --list        Show a list of the files which would be run"
-    print "                Files which would be run are marked with an asterix"
-    print "                symbol [*].  For files which would not be run,"
-    print "                information is given for why they are excluded"
-    print "  --help        Show this help and exit"
-    print "  --version     Show version and copyright information"
-    print
-    print "ENVIRONMENT specifies a list of environments for which to run autostart"
-    print "applications.  If none are specified, only applications which do not "
-    print "limit themselves to certain environments will be run."
-    print
-    print "ENVIRONMENT can be one or more of:"
-    print "  GNOME         Gnome Desktop"
-    print "  KDE           KDE Desktop"
-    print "  ROX           ROX Desktop"
-    print "  XFCE          XFCE Desktop"
-    print "  Old           Legacy systems"
-    print
-    print "*COPYRIGHT*"
-    print "openbox-xdg-autostart was written by Dana Jansens in 2008,"
-    print "and originally provided in openbox under the GPL-2 licence."
-    print
+    print("Usage:", ME, "[OPTION]... [ENVIRONMENT]...")
+    print()
+    print("This tool will run xdg autostart .desktop files")
+    print()
+    print("OPTIONS")
+    print("  --list        Show a list of the files which would be run")
+    print("                Files which would be run are marked with an asterix")
+    print("                symbol [*].  For files which would not be run,")
+    print("                information is given for why they are excluded")
+    print("  --help        Show this help and exit")
+    print("  --version     Show version and copyright information")
+    print()
+    print("ENVIRONMENT specifies a list of environments for which to run autostart")
+    print("applications.  If none are specified, only applications which do not ")
+    print("limit themselves to certain environments will be run.")
+    print()
+    print("ENVIRONMENT can be one or more of:")
+    print("  GNOME         Gnome Desktop")
+    print("  KDE           KDE Desktop")
+    print("  ROX           ROX Desktop")
+    print("  XFCE          XFCE Desktop")
+    print("  Old           Legacy systems")
+    print()
+    print("*COPYRIGHT*")
+    print("openbox-xdg-autostart was written by Dana Jansens in 2008,")
+    print("and originally provided in openbox under the GPL-2 licence.")
+    print()
 
 def show_version():
-    print ME, VERSION
-    print "Copyright (c) 2008        Dana Jansens"
-    print
+    print(ME, VERSION)
+    print("Copyright (c) 2008        Dana Jansens")
+    print()
 
 if __name__ == "__main__":
         sys.exit(main())


### PR DESCRIPTION
The single python script in this package was easily upgraded to python3 with the 2to3 utility. The only changes needed were the print() function and /usr/bin/python3 shebang. (/usr/bin/python will not exist in Debian Bullseye.)