### PR TITLE
Fix comment syntax in prepend.csv

### DIFF
--- a/skel/.config/jgmenu/prepend.csv
+++ b/skel/.config/jgmenu/prepend.csv
@@ -1,9 +1,9 @@
 # BunsenLabs Main Menu
 
-## Bunsenlabs User config files
-## All default BunsenLabs user config files are located in /usr/share/bunsen/skel.
+## BunsenLabs user configuration files
+## All default BunsenLabs user config files are located in /usr/share/bunsen/skel/.
 ## The script bl-user-setup copies them to the user $HOME directory on first login.
-## See more info with command 'bl-user-setup --help'
+## See more info with command { bl-user-setup --help; }
 
 @text,,6,6,150,20,2,left,top,auto,#000000 0,<span size="large">🔍︎</span>
 @search,,24,3,150,20,2,left,top,auto,#000000 0,Type to Search


### PR DESCRIPTION
Fix casing, embedded path syntax and embedded shell command syntax in the introduction to the file prepend.csv