### PR TITLE
add bunsenlabs-wayland.desktop

### DIFF
--- a/debian/bunsen-configs-wayland.install
+++ b/debian/bunsen-configs-wayland.install
@@ -1,0 +1,1 @@
+wayland/wayland-sessions usr/share

--- a/debian/bunsen-configs-wayland.links
+++ b/debian/bunsen-configs-wayland.links
@@ -1,0 +1,1 @@
+usr/bin/bunsenlabs-session usr/bin/bunsenlabs-session-wayland

--- a/wayland/wayland-sessions/bunsenlabs-wayland.desktop
+++ b/wayland/wayland-sessions/bunsenlabs-wayland.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=BunsenLabs Wayland
+Comment=Log in to a BunsenLabs Wayland session
+Exec=/usr/bin/bunsenlabs-session-wayland
+TryExec=/usr/bin/bunsenlabs-session-wayland
+Icon=bunsenlabs
+Type=Application


### PR DESCRIPTION
add install routines for bunsenlabs-wayland.desktop and link bunsenlab-session-wayland -> bunsenlabs-session This is enough for a bunsenlabs-wayland choice in netinstall as other files can be added in the netinstall $HOME dir