### PR TITLE
mime: new dir to add new mime-types. Added type for linux kernel image.

### DIFF
--- a/debian/bunsen-configs-base.install
+++ b/debian/bunsen-configs-base.install
@@ -21,3 +21,4 @@ calendar.bunsen etc/calendar
 Xsession.d etc/X11
 greetd etc
 nwg-hello etc
+mime usr/share

--- a/debian/bunsen-configs-lite.install
+++ b/debian/bunsen-configs-lite.install
@@ -21,3 +21,4 @@ calendar.bunsen etc/calendar
 Xsession.d etc/X11
 greetd etc
 nwg-hello etc
+mime usr/share

--- a/debian/bunsen-configs.install
+++ b/debian/bunsen-configs.install
@@ -20,3 +20,4 @@ calendar.bunsen etc/calendar
 Xsession.d etc/X11
 greetd etc
 nwg-hello etc
+mime usr/share

--- a/mime/packages/application-linux-kernel.xml
+++ b/mime/packages/application-linux-kernel.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/linux-kernel">
+    <comment>linux kernel image</comment>
+    <glob pattern="vmlinuz*"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
This PR adds a mime-type `application/linux-kernel` for the linux kernel such that we get an tux icon rather than the windows icon that usually gets associated with the kernel as it is recognised as `application/x-ms-dos-executable`.
Fur further information see https://forums.bunsenlabs.org/viewtopic.php?pid=142856#p142856 and subsequent posts.